### PR TITLE
add health check path

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -34,6 +34,13 @@ const createServer = () => {
   return http.createServer(async (req, res) => {
     const url = req.url.slice(1)
     accesslog(req, res)
+    if (url === "health") {
+      res.writeHead(200, {
+        'Content-Type': 'text/plain'
+      })
+      res.end('OK')
+      return
+    }
     if (!prefixes.some(prefix => url.startsWith(prefix))) {
       res.writeHead(404, {
         'Content-Type': 'text/plain'


### PR DESCRIPTION
I think it is nice amphtml-validator-server has a health check path.

For example, in kubernetes, we can define liveness and readiness probes against this health check path so that catching deadlocks etc.